### PR TITLE
Older compilers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ jobs:
   test:
     strategy:
       matrix:
-        operating-system: [macos-latest, ubuntu-latest, windows-latest]
-        ocaml-version: [4.11.0, 4.10.0, 4.09.1]
+        operating-system: [ macos-latest, ubuntu-latest ]
+        ocaml-version: [ '4.11.1' ]
     runs-on: ${{ matrix.operating-system }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,5 @@ jobs:
         echo "let () = print_endline Sys.ocaml_version" > main.ml
         $GITHUB_WORKSPACE/ocaml/4.11.1/bin/ocamlopt main.ml -o eleven.out
         ./eleven.out
-        $GITHUB_WORKSPACE/ocaml/4.7.1/bin/ocamlopt main.ml -o seven.out
+        $GITHUB_WORKSPACE/ocaml/4.07.1/bin/ocamlopt main.ml -o seven.out
         ./seven.out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,16 @@ jobs:
       run: opam exec -- dune build
     - name: Installing
       run: opam exec -- dune install
+    - name: Install location
+      run: mkdir -p /home/runner/ocaml
+    - name: Testing (dry run)
+      run: opam exec -- opam sysinstall build --prefix=/home/runner/ocaml --versions=4.11.1,4.07.1 --dry-run
     - name: Testing
-      run: opam exec -- dune runtest
+      run: opam exec -- opam sysinstall build --prefix=/home/runner/ocaml --versions=4.11.1,4.07.1
+    - name: Inspecting
+      run: |
+        echo "let () = print_endline Sys.ocaml_version" > main.ml
+        /home/runner/4.11.1/bin/ocamlopt main.ml -o eleven.out
+        ./eleven.out
+        /home/runner/4.7.1/bin/ocamlopt main.ml -o seven.out
+        ./seven.out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,15 +23,15 @@ jobs:
     - name: Installing
       run: opam exec -- dune install
     - name: Install location
-      run: mkdir -p /home/runner/ocaml
+      run: mkdir -p $GITHUB_WORKSPACE/ocaml
     - name: Testing (dry run)
-      run: opam exec -- opam sysinstall build --prefix=/home/runner/ocaml --versions=4.11.1,4.07.1 --dry-run
+      run: opam exec -- opam sysinstall build --prefix=$GITHUB_WORKSPACE/ocaml --versions=4.11.1,4.07.1 --dry-run
     - name: Testing
-      run: opam exec -- opam sysinstall build --prefix=/home/runner/ocaml --versions=4.11.1,4.07.1
+      run: opam exec -- opam sysinstall build --prefix=$GITHUB_WORKSPACE/ocaml --versions=4.11.1,4.07.1
     - name: Inspecting
       run: |
         echo "let () = print_endline Sys.ocaml_version" > main.ml
-        /home/runner/4.11.1/bin/ocamlopt main.ml -o eleven.out
+        $GITHUB_WORKSPACE/ocaml/4.11.1/bin/ocamlopt main.ml -o eleven.out
         ./eleven.out
-        /home/runner/4.7.1/bin/ocamlopt main.ml -o seven.out
+        $GITHUB_WORKSPACE/ocaml/4.7.1/bin/ocamlopt main.ml -o seven.out
         ./seven.out

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,2 @@
 version=0.15.0
+parse-docstrings=true

--- a/dune-project
+++ b/dune-project
@@ -1,23 +1,22 @@
 (lang dune 2.7)
-
 (cram enable)
-
-(name opam-sysinstall)
-
 (generate_opam_files true)
-
-(source
- (github patricoferris/opam-sysinstall))
-
+(name opam-sysinstall)
+(source (github patricoferris/opam-sysinstall))
 (license ISC)
-
 (authors "Patrick Ferris")
-
 (maintainers "pf341@patricoferris.com")
-
 (package
  (name opam-sysinstall)
  (synopsis "Plugin to add install OCaml system compilers")
  (description
-   "This opam plugin allows you to install a set of OCaml system compilers to a prefix of your choosing")
- (depends bos ocaml-version fmt cmdliner))
+  "This opam plugin allows you to install a set of OCaml system compilers to a prefix of your choosing")
+ (depends
+  (opam-state (>= 2.1.0~beta2))
+  (opam-format (>= 2.1.0~beta2))
+  (opam-core (>= 2.1.0~beta2))
+  (opam-client (>= 2.1.0~beta2))
+  bos
+  ocaml-version
+  fmt
+  cmdliner))

--- a/lib/dune
+++ b/lib/dune
@@ -1,3 +1,3 @@
 (library
  (name opam_sysinstall)
- (libraries ocaml-version cmdliner bos fmt fmt.tty))
+ (libraries ocaml-version cmdliner bos fmt fmt.tty opam-core opam-client opam-format opam-state))

--- a/lib/ocaml.ml
+++ b/lib/ocaml.ml
@@ -1,9 +1,69 @@
 open Bos
+module Ov = Ocaml_version
 
-let configure ?prefix () =
-  match prefix with
-  | None -> Cmd.v "./configure"
-  | Some prefix -> Cmd.(v "./configure" % ("--prefix=" ^ prefix))
+type t = { prefix : string option; cc : string option }
+
+module type Configure = sig
+  val cmdliner : t Cmdliner.Term.t
+
+  val to_list : t -> string list
+
+  val configure : t -> Cmd.t
+end
+
+(* 4.08+ *)
+module Auto_Conf : Configure = struct
+  open Cmdliner
+
+  let prefix =
+    let docv = "PREFIX" in
+    let doc =
+      "The ./configure prefix parameter to use -- defaults to OCaml's built-in \
+       default"
+    in
+    Arg.(value & opt (some string) None & info ~doc ~docv [ "prefix"; "p" ])
+
+  let cc =
+    let docv = "CC" in
+    let doc = "C compiler to use for building the system" in
+    Arg.(value & opt (some string) None & info ~doc ~docv [ "cc" ])
+
+  let cmdliner =
+    let make prefix cc = { prefix; cc } in
+    Term.(const make $ prefix $ cc)
+
+  let to_list t =
+    [ ("prefix", t.prefix); ("cc", t.cc) ]
+    |> List.filter (fun (_, v) -> Option.is_some v)
+    |> List.map (function
+         | k, Some v -> Fmt.str "--%s=%s" k v
+         | _ -> assert false)
+
+  let configure t =
+    let mk_list = to_list in
+    Cmd.(v "./configure" %% of_list (mk_list t))
+end
+
+module Old_Conf : Configure = struct
+  include Auto_Conf
+
+  let to_list t =
+    [ ("-prefix", t.prefix); ("-cc", t.cc) ]
+    |> List.filter (fun (_, v) -> Option.is_some v)
+    |> List.map (function k, Some v -> [ k; v ] | _ -> assert false)
+    |> List.flatten
+
+  let configure t =
+    let mk_list = to_list in
+    Cmd.(v "./configure" %% of_list (mk_list t))
+end
+
+let cmdliner = Auto_Conf.cmdliner
+
+let configure ocv =
+  match Ov.compare ocv (Ov.v 4 8) with
+  | n when n >= 0 -> Auto_Conf.configure
+  | _ -> Old_Conf.configure
 
 let make_world_opt ~jobs =
   Cmd.(v "make" % ("-j" ^ string_of_int jobs) % "world.opt")

--- a/lib/ocaml.mli
+++ b/lib/ocaml.mli
@@ -1,4 +1,22 @@
-val configure : ?prefix:string -> unit -> Bos.Cmd.t
+module Ov = Ocaml_version
+
+type t = { prefix : string option; cc : string option }
+
+module type Configure = sig
+  val cmdliner : t Cmdliner.Term.t
+
+  val to_list : t -> string list
+
+  val configure : t -> Bos.Cmd.t
+end
+
+val cmdliner : t Cmdliner.Term.t
+(** Creating an OCaml configuration from the command line *)
+
+val configure : Ov.t -> t -> Bos.Cmd.t
+(** [configure ocv conf] provides a command to run to configure a particular
+    version of OCaml. This plugin is trying to cater to older (pre-autoconf)
+    versions of the compiler too. *)
 
 val make_world_opt : jobs:int -> Bos.Cmd.t
 

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -1,7 +1,47 @@
-open Bos 
+open Bos
 module Ov = Ocaml_version
 
 let opam = Cmd.v "opam"
 
 let source_compiler ocv =
   Cmd.(opam % "source" % ("ocaml-base-compiler." ^ Ov.to_string ocv))
+
+let get_opam_file ocv =
+  let show =
+    Cmd.(opam % "show" % "--raw" % ("ocaml-base-compiler." ^ Ov.to_string ocv))
+  in
+  OS.Cmd.(to_string (run_out show)) |> function
+  | Ok t -> t
+  | Error (`Msg m) -> failwith m
+
+let build_cmds ocvs =
+  OpamClientConfig.opam_init ();
+  OpamGlobalState.with_ `Lock_none @@ fun gt ->
+  OpamSwitchState.with_ `Lock_read gt @@ fun t ->
+  let filter opam t =
+    OpamFilter.commands
+      (OpamPackageVar.resolve ~opam ~local:OpamVariable.(Map.of_list []) t)
+  in
+  let build opam =
+    let pkg =
+      OpamFile.OPAM.read_from_string opam
+      |> OpamFile.OPAM.with_name
+           (OpamPackage.Name.of_string "ocaml-base-compiler")
+    in
+    let cmds = OpamFile.OPAM.build pkg in
+    cmds |> filter pkg t
+  in
+  let filter_before_configure lst =
+    let rec aux acc = function
+      | [] -> List.rev acc
+      | ("./configure" :: _) :: _ -> List.rev acc
+      | x :: xs -> aux (x :: acc) xs
+    in
+    aux [] lst
+  in
+  List.map
+    (fun ocv ->
+      ( ocv,
+        build (get_opam_file ocv)
+        |> filter_before_configure |> List.map Cmd.of_list ))
+    ocvs

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -1,2 +1,6 @@
-val source_compiler : Ocaml_version.t -> Bos.Cmd.t 
+val source_compiler : Ocaml_version.t -> Bos.Cmd.t
 (** A command to get the source code for a specific version of an OCaml compiler *)
+
+val build_cmds : Ocaml_version.t list -> (Ocaml_version.t * Bos.Cmd.t list) list
+(** [build_cmds ocv] gets the commands to run before [configure] from the OCaml
+    base compiler opam file *)

--- a/opam-sysinstall.opam
+++ b/opam-sysinstall.opam
@@ -10,6 +10,10 @@ homepage: "https://github.com/patricoferris/opam-sysinstall"
 bug-reports: "https://github.com/patricoferris/opam-sysinstall/issues"
 depends: [
   "dune" {>= "2.7"}
+  "opam-state" {>= "2.1.0~beta2"}
+  "opam-format" {>= "2.1.0~beta2"}
+  "opam-core" {>= "2.1.0~beta2"}
+  "opam-client" {>= "2.1.0~beta2"}
   "bos"
   "ocaml-version"
   "fmt"

--- a/tests/bin/run.t
+++ b/tests/bin/run.t
@@ -5,41 +5,28 @@ Malformed OCaml versions fail
    -- reason: Unable to parse OCaml version 'foo'
   [255]
 
-Versions earlier than 4.08 are parsed, but fail 
-
-  $ opam sysinstall build --versions=4.07
-  [ SUCCESS ] Parsing Compiler Versions
-  [ ERROR ] Filtered out all OCaml Versions
-  [255]
-
-Quiet removes success message 
-
-  $ opam sysinstall build --versions=4.07 --quiet
-  [ ERROR ] Filtered out all OCaml Versions
-  [255]
-
 Dry run should have something sensible 
 
   $ opam sysinstall build --latest=1 --dry-run
-  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.11.0'
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.11.1'
   [ INFO ] './configure'
   [ INFO ] 'make' '-j1' 'world.opt'
   [ INFO ] 'make' 'install'
-  [ SUCCESS ] system compiler 4.11.0 installed
+  [ SUCCESS ] system compiler 4.11.1 installed
 
-Filter out any compiler versions less than 4.08 and should add the extra prefix
+Filter out any compiler versions less than 4.02 and should add the extra prefix
 
-  $ opam sysinstall build --latest=7 --dry-run
-  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.11.0'
-  [ INFO ] './configure' '--prefix=/usr/local/4.11.0'
+  $ opam sysinstall build --latest=10 --dry-run
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.11.1'
+  [ INFO ] './configure' '--prefix=/usr/local/4.11.1'
   [ INFO ] 'make' '-j1' 'world.opt'
   [ INFO ] 'make' 'install'
-  [ SUCCESS ] system compiler 4.11.0 installed
-  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.10.1'
-  [ INFO ] './configure' '--prefix=/usr/local/4.10.1'
+  [ SUCCESS ] system compiler 4.11.1 installed
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.10.2'
+  [ INFO ] './configure' '--prefix=/usr/local/4.10.2'
   [ INFO ] 'make' '-j1' 'world.opt'
   [ INFO ] 'make' 'install'
-  [ SUCCESS ] system compiler 4.10.1 installed
+  [ SUCCESS ] system compiler 4.10.2 installed
   [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.09.1'
   [ INFO ] './configure' '--prefix=/usr/local/4.09.1'
   [ INFO ] 'make' '-j1' 'world.opt'
@@ -50,20 +37,50 @@ Filter out any compiler versions less than 4.08 and should add the extra prefix
   [ INFO ] 'make' '-j1' 'world.opt'
   [ INFO ] 'make' 'install'
   [ SUCCESS ] system compiler 4.08.1 installed
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.07.1'
+  [ INFO ] './configure' '-prefix' '/usr/local/4.07.1'
+  [ INFO ] 'make' '-j1' 'world.opt'
+  [ INFO ] 'make' 'install'
+  [ SUCCESS ] system compiler 4.07.1 installed
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.06.1'
+  [ INFO ] './configure' '-prefix' '/usr/local/4.06.1'
+  [ INFO ] 'make' '-j1' 'world.opt'
+  [ INFO ] 'make' 'install'
+  [ SUCCESS ] system compiler 4.06.1 installed
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.05.0'
+  [ INFO ] './configure' '-prefix' '/usr/local/4.05.0'
+  [ INFO ] 'make' '-j1' 'world.opt'
+  [ INFO ] 'make' 'install'
+  [ SUCCESS ] system compiler 4.05.0 installed
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.04.2'
+  [ INFO ] './configure' '-prefix' '/usr/local/4.04.2'
+  [ INFO ] 'make' '-j1' 'world.opt'
+  [ INFO ] 'make' 'install'
+  [ SUCCESS ] system compiler 4.04.2 installed
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.03.0'
+  [ INFO ] './configure' '-prefix' '/usr/local/4.03.0'
+  [ INFO ] 'make' '-j1' 'world.opt'
+  [ INFO ] 'make' 'install'
+  [ SUCCESS ] system compiler 4.03.0 installed
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.02.3'
+  [ INFO ] './configure' '-prefix' '/usr/local/4.02.3'
+  [ INFO ] 'make' '-j1' 'world.opt'
+  [ INFO ] 'make' 'install'
+  [ SUCCESS ] system compiler 4.02.3 installed
 
 Use the user-define prefix 
 
   $ opam sysinstall build --latest=2 --dry-run --prefix=/data/ocaml
-  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.11.0'
-  [ INFO ] './configure' '--prefix=/data/ocaml/4.11.0'
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.11.1'
+  [ INFO ] './configure' '--prefix=/data/ocaml/4.11.1'
   [ INFO ] 'make' '-j1' 'world.opt'
   [ INFO ] 'make' 'install'
-  [ SUCCESS ] system compiler 4.11.0 installed
-  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.10.1'
-  [ INFO ] './configure' '--prefix=/data/ocaml/4.10.1'
+  [ SUCCESS ] system compiler 4.11.1 installed
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.10.2'
+  [ INFO ] './configure' '--prefix=/data/ocaml/4.10.2'
   [ INFO ] 'make' '-j1' 'world.opt'
   [ INFO ] 'make' 'install'
-  [ SUCCESS ] system compiler 4.10.1 installed
+  [ SUCCESS ] system compiler 4.10.2 installed
 
 Run with ALL the jobs 
 
@@ -74,3 +91,23 @@ Run with ALL the jobs
   [ INFO ] 'make' '-j64' 'world.opt'
   [ INFO ] 'make' 'install'
   [ SUCCESS ] system compiler 4.11 installed
+
+Add cc option 
+
+  $ opam sysinstall build --versions=4.11 --cc=gcc --dry-run
+  [ SUCCESS ] Parsing Compiler Versions
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.11'
+  [ INFO ] './configure' '--cc=gcc'
+  [ INFO ] 'make' '-j1' 'world.opt'
+  [ INFO ] 'make' 'install'
+  [ SUCCESS ] system compiler 4.11 installed
+
+Older versions of the compiler render differently
+
+  $ opam sysinstall build --versions=4.07.0 --prefix=/home/ocaml --cc=gcc --dry-run
+  [ SUCCESS ] Parsing Compiler Versions
+  [ INFO ] 'opam' 'source' 'ocaml-base-compiler.4.07.0'
+  [ INFO ] './configure' '-prefix' '/home/ocaml' '-cc' 'gcc'
+  [ INFO ] 'make' '-j1' 'world.opt'
+  [ INFO ] 'make' 'install'
+  [ SUCCESS ] system compiler 4.07.0 installed


### PR DESCRIPTION
This PR adds support for older compilers to be system installed. No windows support just yet as I can't use `ocaml-base-compiler` with the fdopen's opam repo. 